### PR TITLE
[FEAT] pagination 구현

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -54,24 +54,25 @@ const router = createBrowserRouter([
         path: '/signup',
         element: <SignUp />,
       },
+      // {
+      //   path: '/computer-it',
+      //   element: <ComputerIt />,
+      //   children: [
+      //     { index: true, element: <Community category="computer-it" /> },
+      //     {
+      //       path: ':subCategory',
+      //       loader: postsByCategoryLoader(queryClient),
+      //       element: <Community category="computer-it" />,
+      //     },
+      //     {
+      //       path: 'list/popular',
+      //       element: <PopularPosts category="computer-it" />,
+      //     },
+      //   ],
+      // },
       {
-        path: '/computer-it',
-        element: <ComputerIt />,
-        children: [
-          { index: true, element: <Community category="computer-it" /> },
-          {
-            path: ':subCategory',
-            loader: postsByCategoryLoader(queryClient),
-            element: <Community category="computer-it" />,
-          },
-          {
-            path: 'list/popular',
-            element: <PopularPosts category="computer-it" />,
-          },
-        ],
-      },
-      {
-        path: '/game',
+        path: ':category',
+        loader: postsByCategoryLoader(queryClient),
         element: <Game />,
         children: [
           { index: true, element: <Community category="game" /> },

--- a/client/src/components/community/CommunityCategorySection.jsx
+++ b/client/src/components/community/CommunityCategorySection.jsx
@@ -18,8 +18,8 @@ const CategoryImage = styled(Image)`
   }
 `;
 
-const CommunityCategorySection = ({ category }) => {
-  const { subCategory } = useParams();
+const CommunityCategorySection = () => {
+  const { category, subCategory } = useParams();
 
   return (
     <>
@@ -34,7 +34,7 @@ const CommunityCategorySection = ({ category }) => {
           <AutoComplete width={720} queryFn={getSearchedPosts} category={category} subCategory={subCategory} />
         </Flex>
       </Flex>
-      <PostSection queryFn={postsByCategoryQuery(subCategory)} />
+      <PostSection queryFn={postsByCategoryQuery({ category, subCategory })} />
     </>
   );
 };

--- a/client/src/components/community/posts/PostSection.jsx
+++ b/client/src/components/community/posts/PostSection.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Chip, Flex, Group, List, Text, Burger, Divider } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import FILTERS from '../../../constants/filters';
 import { EmptyPostIndicator, PostItem, ShowMoreButton, SideFilter } from '..';
 import filterPosts from '../../../utils/filterPosts';
 import sortPosts from '../../../utils/sortPosts';
-import { getPosts } from '../../../../firebase/posts';
 
 const PostsContainer = styled(Flex)`
   margin-top: 1rem;
@@ -23,11 +22,9 @@ const MyPosts = styled(List)`
 `;
 
 const PostSection = ({ queryFn, isShownQuestionButton = true }) => {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(queryFn);
-  const { data: posts } = useQuery({
-    queryKey: ['postsFire'],
-    queryFn: getPosts,
-  });
+  const { data: posts, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(queryFn);
+
+  console.log(posts);
 
   const [currentSort, setCurrentSort] = React.useState('recent');
   const [currentFilter, setCurrentFilter] = React.useState(FILTERS.all);
@@ -42,7 +39,7 @@ const PostSection = ({ queryFn, isShownQuestionButton = true }) => {
           질문
         </Text>
         <Text c="blue" fz="2.5rem">
-          {data?.totalLength}
+          {posts?.totalLength}
         </Text>
       </Flex>
       <Divider mb="1rem" variant="dashed" />

--- a/client/src/components/community/posts/PostSection.jsx
+++ b/client/src/components/community/posts/PostSection.jsx
@@ -24,8 +24,6 @@ const MyPosts = styled(List)`
 const PostSection = ({ queryFn, isShownQuestionButton = true }) => {
   const { data: posts, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(queryFn);
 
-  console.log(posts);
-
   const [currentSort, setCurrentSort] = React.useState('recent');
   const [currentFilter, setCurrentFilter] = React.useState(FILTERS.all);
   const [opened, { toggle }] = useDisclosure(false);
@@ -72,7 +70,7 @@ const PostSection = ({ queryFn, isShownQuestionButton = true }) => {
           <EmptyPostIndicator isShownButton={isShownQuestionButton} />
         )}
       </PostsContainer>
-      {posts?.length > 0 && hasNextPage && <ShowMoreButton onClick={fetchNextPage} loading={isFetchingNextPage} />}
+      {hasNextPage && <ShowMoreButton onClick={fetchNextPage} loading={isFetchingNextPage} />}
     </>
   );
 };

--- a/client/src/loaders/postsByCategoryLoader.js
+++ b/client/src/loaders/postsByCategoryLoader.js
@@ -3,7 +3,7 @@ import { postsByCategoryQuery } from '../queries';
 const postsByCategoryLoader =
   queryClient =>
   async ({ params }) => {
-    const query = postsByCategoryQuery(params.category);
+    const query = postsByCategoryQuery(params);
 
     // eslint-disable-next-line no-return-await
     return queryClient.getQueryData(query.queryKey) ?? (await queryClient.fetchInfiniteQuery(query));

--- a/client/src/queries/postsByCategoryQuery.js
+++ b/client/src/queries/postsByCategoryQuery.js
@@ -7,8 +7,7 @@ const postsByCategoryQuery = ({ category, subCategory }) => ({
   queryKey: ['category', category, subCategory],
   queryFn: async ({ pageParam }) => getPostsByCategory({ category, subCategory, pageParam }),
 
-  getNextPageParam: lastPage => (lastPage.size === 10 ? lastPage[lastPage.docs.length - 1] : undefined),
-
+  getNextPageParam: lastPage => (lastPage.size === 10 ? lastPage.docs[lastPage.docs.length - 1] : undefined),
   select: ({ pages }) => pages.map(postSnapshot => specifySnapshotIntoData(postSnapshot)).flat(),
   staleTime,
 });

--- a/client/src/queries/postsByCategoryQuery.js
+++ b/client/src/queries/postsByCategoryQuery.js
@@ -1,25 +1,15 @@
-import { getPostsByCategory } from '../api/posts';
+import { getPostsByCategory } from '../../firebase/posts';
+import { specifySnapshotIntoData } from '../../firebase/utils';
 
 const staleTime = 3000;
 
-const postsByCategoryQuery = category => ({
-  queryKey: ['category', category],
-  queryFn: async ({ pageParam = 1 }) => {
-    const { data } = await getPostsByCategory({ param: category, pageParam });
-    return data;
-  },
-  getNextPageParam: (lastPage, allPages) => {
-    const nextPage = allPages.length + 1;
-    const { totalLength } = lastPage;
+const postsByCategoryQuery = ({ category, subCategory }) => ({
+  queryKey: ['category', category, subCategory],
+  queryFn: async ({ pageParam }) => getPostsByCategory({ category, subCategory, pageParam }),
 
-    return totalLength === 0 || Math.ceil(totalLength / allPages[0].posts.length) === allPages.length
-      ? undefined
-      : nextPage;
-  },
-  select: data => ({
-    posts: data.pages.map(({ posts }) => posts).flat(),
-    totalLength: data.pages[0].totalLength,
-  }),
+  getNextPageParam: lastPage => (lastPage.size === 10 ? lastPage[lastPage.docs.length - 1] : undefined),
+
+  select: ({ pages }) => pages.map(postSnapshot => specifySnapshotIntoData(postSnapshot)).flat(),
   staleTime,
 });
 


### PR DESCRIPTION
- category page route 변경
  - loader에서 params로 category / subcategory 둘 다 받을 수 있도록 수정
  - 중복 제거

- pagination 코드 추가
  - postBycategrory 적용
  - myPosts 적용

- category 페이지의 loader 및 query  수정
  - 변경된 pagination 코드 적용

 TODO : 글 전체 갯수 가져오기