### PR TITLE
[FEAT] 내가 좋아요 누른 글 목록 페이지, query 구현

### DIFF
--- a/client/src/components/common/InfoCard.jsx
+++ b/client/src/components/common/InfoCard.jsx
@@ -23,7 +23,7 @@ const MoreButton = styled(Button)`
   justify-content: center;
   align-items: center;
   padding-right: 12px;
-  border-radius: 20px;
+  border-radius: 10px;
 `;
 
 /**

--- a/client/src/components/common/PopupModal.jsx
+++ b/client/src/components/common/PopupModal.jsx
@@ -70,8 +70,8 @@ const PopupModal = ({ opened, onClose, title, children }) => (
     radius="18px"
     size="50%"
     overlayProps={{
-      opacity: 0.55,
-      blur: 1,
+      opacity: 0.25,
+      blur: 2.5,
     }}
     centered>
     {children}

--- a/client/src/components/common/nav/ProfileSubMenu.jsx
+++ b/client/src/components/common/nav/ProfileSubMenu.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Recoil from 'recoil';
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 import { Flex, Group, Menu, Text } from '@mantine/core';
 import userState from '../../../recoil/atoms/userState';
 
@@ -28,7 +29,7 @@ const SubMenuWrapper = styled.div`
   flex-direction: column;
 `;
 
-const SubMenuItem = styled(Menu.Item)`
+const SubMenuItem = styled(Link)`
   font-size: ${({ size }) => (size === 'sm' ? '15px' : size === 'md' ? '18px' : '22px')};
   font-weight: ${({ size }) => (size === 'sm' ? '400' : size === 'md' ? '600' : '700')};
   margin-top: ${({ size }) => size === 'sm' && '8px'};
@@ -60,19 +61,23 @@ const ProfileSubMenu = ({ menuItems, handleLogout }) => {
     <SubMenuContainer>
       <SubMenuWrapper>
         <Flex direction="column" px="6px" mb="10px">
-          <Text fz="lg" fw="600">{`${nickName} 님`}</Text>
+          <Text
+            variant="gradient"
+            gradient={{ from: 'indigo', to: 'cyan', deg: 45 }}
+            fz="32px"
+            fw="600">{`${nickName} 님`}</Text>
           <Group>
             <Text>레벨 {level}</Text>
             <Text>포인트 {point}</Text>
           </Group>
         </Flex>
-        <Flex direction="column">
+        <Flex direction="column" justify="start">
           {menuItems.map(({ size, content, path }) => (
-            <SubMenuItem key={`${content}-${path}`} size={size} component="a" href={path}>
+            <SubMenuItem key={`${content}-${path}`} size={size} to={path}>
               {content}
             </SubMenuItem>
           ))}
-          <SubMenuItem key={'로그아웃'} size="sm" component="a" onClick={handleLogout}>
+          <SubMenuItem key={'로그아웃'} size="sm" onClick={handleLogout}>
             {'로그아웃'}
           </SubMenuItem>
         </Flex>

--- a/client/src/components/community/home/QuestionInfoModal.jsx
+++ b/client/src/components/community/home/QuestionInfoModal.jsx
@@ -33,7 +33,7 @@ const QuestionInfoModal = ({ opened, onClose }) => (
     </List>
     <Divider color="var(--opacity-border-color)" />
     <Text mt="20px">
-      {`질문 해결에 도움이 된 답변에`} <HighlightText>[채택된 답변] </HighlightText>
+      {`질문 해결에 도움이 된 답변에`} <HighlightText>채택된 답변 </HighlightText>
       {` 표시를 하여 도움을 준 커뮤니티 회원의 노고를 인정해 줍니다. 그러면 해당 회원은 포인트를 지급받아 커뮤니티에서 레벨이 올라갑니다.`}
     </Text>
   </PopupModal>

--- a/client/src/components/community/posts/PostItem.jsx
+++ b/client/src/components/community/posts/PostItem.jsx
@@ -76,7 +76,7 @@ const PostItem = ({ post: { id, title, createAt, category, subCategory, complete
                   </Text>
                 </Flex>
                 <Flex mr="1rem" gap="0.4rem" align="center">
-                  <AiFillHeart size="20" color="#F59F01" />
+                  <AiFillHeart size="20" color="var(--like-color)" />
                   <Text fz="1.2rem" fw="500">
                     {like.length}
                   </Text>

--- a/client/src/components/profile/MyProfile.jsx
+++ b/client/src/components/profile/MyProfile.jsx
@@ -89,7 +89,7 @@ const MyProfile = () => {
           <Badge size="md" fz="md" mt="2px">{`L${level}`}</Badge>
           <Text fz="1rem" fw="400">{`${point} 포인트`}</Text>
         </Flex>
-        <Button mt="30px" size="sm" onClick={handleEdit}>
+        <Button mt="30px" size="sm" radius="10px" onClick={handleEdit}>
           프로필 편집
         </Button>
       </Container>

--- a/client/src/pages/MyFavPosts.jsx
+++ b/client/src/pages/MyFavPosts.jsx
@@ -1,8 +1,35 @@
 import React from 'react';
+import Recoil from 'recoil';
+import styled from '@emotion/styled';
+import { Container, Title } from '@mantine/core';
+import { Loader, PostSection } from '../components';
+import { myLikePostsQuery } from '../queries';
+import userState from '../recoil/atoms/userState';
+
+const Wrapper = styled(Container)`
+  min-width: 1024px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-top: 1rem;
+  margin-bottom: 5rem;
+  font-size: 0.75rem;
+  color: var(--font-color);
+`;
 
 const MyFavPosts = () => {
-  console.log('todo');
-  return <div>좋아요 글 목록</div>;
+  const user = Recoil.useRecoilValue(userState);
+
+  return (
+    <Wrapper>
+      <Title size="52px" mt="40px">
+        🫰 좋아요
+      </Title>
+      <React.Suspense fallback={<Loader />}>
+        <PostSection queryFn={myLikePostsQuery(user.email)} />
+      </React.Suspense>
+    </Wrapper>
+  );
 };
 
 export default MyFavPosts;

--- a/client/src/pages/MyPosts.jsx
+++ b/client/src/pages/MyPosts.jsx
@@ -24,7 +24,7 @@ const MyPosts = () => {
   return (
     <Wrapper>
       <Title size="52px" mt="40px">
-        내가 작성한 질문
+        👨‍🚀 내가 작성한 질문
       </Title>
       <React.Suspense fallback={<Loader />}>
         <PostSection queryFn={myPostsQuery(user.email)} />

--- a/client/src/queries/index.js
+++ b/client/src/queries/index.js
@@ -1,5 +1,6 @@
 export { default as postsByCategoryQuery } from './postsByCategoryQuery';
 export { default as postDetailQuery } from './postDetailQuery';
+export { default as myLikePostsQuery } from './myLikePostsQuery';
 export { default as myPostsQuery } from './myPostsQuery';
 export { default as rankQuery } from './rankQuery';
 export { default as myProfileQuery } from './myProfileQuery';

--- a/client/src/queries/myLikePostsQuery.js
+++ b/client/src/queries/myLikePostsQuery.js
@@ -1,0 +1,20 @@
+import { getMyLikePosts } from '../services/posts';
+
+const staleTime = 3000;
+
+const myLikePostsQuery = author => ({
+  queryKey: ['myLikePosts', author],
+  queryFn: async ({ pageParam }) => {
+    const data = await getMyLikePosts({ author, pageParam });
+    return data;
+  },
+  getNextPageParam: lastPage => lastPage.nextPage,
+  select: ({ pages }) => ({
+    posts: pages.map(({ posts }) => posts).flat(),
+    totalLength: pages[0].totalLength,
+  }),
+  staleTime,
+  suspense: true,
+});
+
+export default myLikePostsQuery;

--- a/client/src/services/posts.js
+++ b/client/src/services/posts.js
@@ -130,14 +130,13 @@ const getProfileWithPosts = async ({ author, pageParam }) => {
   return { posts: await addCommentsLengthListInPosts(data), totalLength, nextPage };
 };
 
-// Todo: Loader 적용 고려
 const getMyLikePosts = async ({ author, pageParam }) => {
-  const { data, totalLength, nextPage } = paginationQuery({
+  const { data, totalLength, nextPage } = await paginationQuery({
     collectionName: COLLECTION,
     pageParam,
     searchCondition: where('like', 'array-contains', author),
   });
-  console.log(data);
+
   return { posts: await addCommentsLengthListInPosts(data), totalLength, nextPage };
 };
 


### PR DESCRIPTION
### Change

- `--like-color` css 변수 `postItem` 컴포넌트 좋아요 개수 아이콘에 반영
- `MyFavPosts` 내가 좋아요 누른 글 목록 페이지, query 구현
   - `Suspense` 구현
   - `useInfiniteQuery`에 전달할 인수 `myLikePostsQuery` 구현
- `ProfileSubmenu` 닉네임 스타일 수정, component a로 인한 화면 깜빡임 해결(`Link` 컴포넌트로 구현)